### PR TITLE
日历组件添加初始化选定日期[（上/下）个（月/月初/月末）]

### DIFF
--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -156,7 +156,7 @@ export default {
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH') {
       var date = new Date();
-      this.currentValue = this.getPreMonth(format(date),'YYYY-MM-DD'))
+      this.currentValue = this.getPreMonth(format(date,'YYYY-MM-DD'))
       this.$emit('input', this.currentValue)
     } else if (this.value === 'LASTMONTH_FIRST') {
       var date = new Date();


### PR DESCRIPTION
日历组件当前初始化选定日期为当前日期，添加了初始化选定日期上个月、下个月、上个月初、上个月末、下个月初、下个月末。

Please makes sure the items are checked before submitting your PR, thank you!

* [ ] `Rebase` before creating a PR to keep commit history clear.
* [ ] `Only One commit`
* [ ] No `eslint` errors
